### PR TITLE
Upgrade langchain to 0.0.148.

### DIFF
--- a/packages/components/nodes/agents/BabyAGI/BabyAGI.ts
+++ b/packages/components/nodes/agents/BabyAGI/BabyAGI.ts
@@ -1,7 +1,7 @@
 import { INode, INodeData, INodeParams } from '../../../src/Interface'
 import { BabyAGI } from './core'
 import { BaseChatModel } from 'langchain/chat_models/base'
-import { VectorStore } from 'langchain/vectorstores'
+import { VectorStore } from 'langchain/vectorstores/base'
 
 class BabyAGI_Agents implements INode {
     label: string

--- a/packages/components/nodes/chains/VectorDBQAChain/VectorDBQAChain.ts
+++ b/packages/components/nodes/chains/VectorDBQAChain/VectorDBQAChain.ts
@@ -2,7 +2,7 @@ import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Inter
 import { getBaseClasses } from '../../../src/utils'
 import { VectorDBQAChain } from 'langchain/chains'
 import { BaseLanguageModel } from 'langchain/base_language'
-import { VectorStore } from 'langchain/vectorstores'
+import { VectorStore } from 'langchain/vectorstores/base'
 import { ConsoleCallbackHandler, CustomChainHandler } from '../../../src/handler'
 
 class VectorDBQAChain_Chains implements INode {

--- a/packages/components/nodes/chatmodels/GoogleVertexAI/ChatGoogleVertexAI.ts
+++ b/packages/components/nodes/chatmodels/GoogleVertexAI/ChatGoogleVertexAI.ts
@@ -98,7 +98,7 @@ class GoogleVertexAI_ChatModels implements INode {
         const maxOutputTokens = nodeData.inputs?.maxOutputTokens as string
         const topP = nodeData.inputs?.topP as string
 
-        const obj: Partial<GoogleVertexAIChatInput> = {
+        const obj: Partial<GoogleVertexAIChatInput<GoogleAuthOptions>> = {
             temperature: parseFloat(temperature),
             model: modelName,
             authOptions

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
         "google-auth-library": "^9.0.0",
         "graphql": "^16.6.0",
         "html-to-text": "^9.0.5",
-        "langchain": "^0.0.128",
+        "langchain": "^0.0.148",
         "linkifyjs": "^4.1.1",
         "mammoth": "^1.5.1",
         "moment": "^2.29.3",


### PR DESCRIPTION
This version moves VectorStore type to a base path. Update references.

This version also requires a type param in the vertex chatmodel, so add that.

Creating as a draft initially, until we've completed manual testing.